### PR TITLE
add: 本番環境でメール送信が行えるように、SendGridアドオンを追加しました

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,20 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "academic_app_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
+  
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'bibliothequebooks.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    :address        => 'smtp.sendgrid.net',
+    :port           => '587',
+    :authentication => :plain,
+    :user_name      => ENV['SENDGRID_USERNAME'],
+    :password       => ENV['SENDGRID_PASSWORD'],
+    :domain         => 'heroku.com',
+    :enable_starttls_auto => true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
HerokuアドオンのSendGridを利用して、本番環境にてメール送信ができるように設定しました。